### PR TITLE
Skip FocusOut exit if focus was lost quickly after start

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,7 +55,7 @@ type engine struct {
 	historyPrefix string
 	historyIndex  uint32
 
-	startTime int64
+	startTime time.Time
 }
 
 func (e *engine) exit() {
@@ -374,7 +374,7 @@ func (e *engine) FocusOut() *dbus.Error {
 	log.Printf("FocusOut()")
 
 	// TODO: The timeout or the whole functionality could be made configurable
-	if time.Now().UnixMilli() < e.startTime + 250 {
+	if time.Since(e.startTime) < 250 * time.Millisecond {
 		log.Printf("FocusOut was quickly after starting. Skipping exit")
 	} else {
 		e.clearText()
@@ -425,7 +425,8 @@ func (e *engine) CandidateClicked(index uint32, button uint32, state uint32) *db
 
 func (e *engine) Enable() *dbus.Error {
 	log.Printf("Enable()")
-	e.startTime = time.Now().UnixMilli()
+
+	e.startTime = time.Now()
 
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -373,7 +373,7 @@ func (e *engine) FocusIn() *dbus.Error {
 func (e *engine) FocusOut() *dbus.Error {
 	log.Printf("FocusOut()")
 
-	if time.Since(e.startTime) < 250 * time.Millisecond {
+	if time.Since(e.startTime) < 250*time.Millisecond {
 		log.Printf("FocusOut was quickly after starting. Skipping exit")
 	} else {
 		e.clearText()

--- a/main.go
+++ b/main.go
@@ -373,7 +373,6 @@ func (e *engine) FocusIn() *dbus.Error {
 func (e *engine) FocusOut() *dbus.Error {
 	log.Printf("FocusOut()")
 
-	// TODO: The timeout or the whole functionality could be made configurable
 	if time.Since(e.startTime) < 250 * time.Millisecond {
 		log.Printf("FocusOut was quickly after starting. Skipping exit")
 	} else {

--- a/main.go
+++ b/main.go
@@ -54,6 +54,8 @@ type engine struct {
 	history       *history
 	historyPrefix string
 	historyIndex  uint32
+
+	startTime int64
 }
 
 func (e *engine) exit() {
@@ -371,8 +373,13 @@ func (e *engine) FocusIn() *dbus.Error {
 func (e *engine) FocusOut() *dbus.Error {
 	log.Printf("FocusOut()")
 
-	e.clearText()
-	e.exit()
+	// TODO: The timeout or the whole functionality could be made configurable
+	if time.Now().UnixMilli() < e.startTime + 250 {
+		log.Printf("FocusOut was quickly after starting. Skipping exit")
+	} else {
+		e.clearText()
+		e.exit()
+	}
 
 	return nil
 }
@@ -418,6 +425,7 @@ func (e *engine) CandidateClicked(index uint32, button uint32, state uint32) *db
 
 func (e *engine) Enable() *dbus.Error {
 	log.Printf("Enable()")
+	e.startTime = time.Now().UnixMilli()
 
 	return nil
 }


### PR DESCRIPTION
This addresses the discussion in #5 