### PR TITLE
Add support for configuring arbitrary command prefixes via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ documentation.
 
 That's it! Shin is now just a keypress away whenever you need it.
 
+### Step 4: Optionally configure a custom command
+
+If you are using shin to always run some specific command, you can edit the 
+`SHIN_DEFAULT_COMMAND`. It will append this to any bash shell you run. This environment
+variable can be set in your `~/.profile`, for example: 
+
+```bash
+export SHIN_DEFAULT_COMMAND="cowsay"
+```
+
 
 ## The `shin/bin` directory
 

--- a/main.go
+++ b/main.go
@@ -170,7 +170,10 @@ func (e *engine) ProcessKeyEvent(keyval uint32, keycode uint32, state uint32) (b
 		}
 
 		binDirectory := filepath.Join(xdg.ConfigHome, "shin", "bin")
-		commandText := fmt.Sprintf(`PATH="%v:$PATH" && %v`, binDirectory, e.text)
+
+        // Optionally use a preconfigured command prefix
+        defaultCommand := os.Getenv("SHIN_DEFAULT_COMMAND")
+ 		commandText := fmt.Sprintf(`PATH="%v:$PATH" && %v %v`, binDirectory, defaultCommand, e.text)
 
 		command := exec.Command("bash", "-c", commandText)
 		output, err := command.CombinedOutput()

--- a/main.go
+++ b/main.go
@@ -171,8 +171,8 @@ func (e *engine) ProcessKeyEvent(keyval uint32, keycode uint32, state uint32) (b
 
 		binDirectory := filepath.Join(xdg.ConfigHome, "shin", "bin")
 
-        // Optionally use a preconfigured command prefix
-        defaultCommand := os.Getenv("SHIN_DEFAULT_COMMAND")
+ 		// Optionally use a preconfigured command prefix
+ 		defaultCommand := os.Getenv("SHIN_DEFAULT_COMMAND")
  		commandText := fmt.Sprintf(`PATH="%v:$PATH" && %v %v`, binDirectory, defaultCommand, e.text)
 
 		command := exec.Command("bash", "-c", commandText)


### PR DESCRIPTION
Hey folks, I realized I wanted to be able to run ChatGPT commands from anywhere in my computer. I forked `shin`, made it configurable via environment variables, then wrote a short project for calling chat GPT (https://github.com/apockill/clai).

Anyways, I figured other folks might benefit from this addition.